### PR TITLE
Parse Options from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,23 @@
 
 <p align="center"> <strong>gitinit</strong> is a bash script for creating an empty repo and pushing an intial commit to github.</p>
 
+## Feature
+
+- create private repository
+- save license file
+- configure git config on repository basis
+- password-less operation
+
 [Installation](#installation) | [Setup](#setup) | [Usage](#usage)
 
 ## Installation 
+
+Setting gitinit is as simple cloning the repo, saving your SSH key on github, generating "Personal Access Token" and running the script.  
+
+Install jq, cli json parser
+```sh
+$ sudo apt instal jq
+```
 
 Clone the repo to your local machine 
 ```sh
@@ -26,18 +40,19 @@ replace `muse-sisay` with your Github username. Only used for identification pur
 
 ```sh
 $ cd ~/.ssh
-$ ssh-keygen -f github-musesisay
+$ ssh-keygen -f github-muse-sisay
 ```
 
-[Github guide](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+Follow the [Github guide](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) to add your public key to your github account.
 
 ### Edit ssh config
 
-Add this to your `~/.ssh/config`. Replace IdentityFile with the one you created. This will allow you to push commits with out providing a password.
+Add this to your `~/.ssh/config`. Replace IdentityFile with the one you created. This will allow you to push commits with out providing a password. `Host` directive should be github- plus your username `github-{username}`.
 
 ```text
-Host github.com
-    IdentityFile ~/.ssh/github-musesisay
+Host github-muse-sisay
+    Hostname github.com
+    IdentityFile ~/.ssh/github-muse-sisay
     IdentitiesOnly yes
     Port 22
 ```
@@ -58,11 +73,31 @@ $ chmod 600 ghAccessToken
 
 ## Usage
 
+
 ```sh 
-$ gitinit -t token -u muse-sisay -r sampleRepo -l mit
+$ gitinit -l mit sampleRepo
+```
+This will create a `sampleRepo` with `MIT` License on Github.
+
+
+```sh
+$ gitinit -l gpl-3.0 -u abebe workRepo
 ```
 
-This will create a `sampleRepo` repository on github.
+Will create `workRepo` with `gpl-3.0` License on `abebe's` Github. If you haven't setup an ssh key-pair and made an edit to ~/.ssh/config .... go ahead folllow [setup](#setup) do it. The Hostname directive in this case would be github-abebe.
+
+```sh
+$ cd ~/.ssh
+$ ssh-keygen -f github-abebe
+```
+
+```text
+Host github-abebe
+    Hostname github.com
+    IdentityFile ~/.ssh/github-abebe
+    IdentitiesOnly yes
+    Port 22
+```
 
 ## TODO 
-- [ ] Securely store Access Token
+- [x] Securely store Access Token (hopefully it's secure)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,63 @@
+<sub>*I don't understand why you would use this instead of https://cli.github.com/manual/*</sub>
 
-// make sure you change your github username 
-// make sure to put the script inside your project folder and give it permission to run
+# Git-init 
+
+<p align="center"> <strong>gitinit</strong> is a bash script for creating an empty repo and pushing an intial commit to github.</p>
+
+[Installation](#installation) | [Setup](#setup) | [Usage](#usage)
+
+## Installation 
+
+Clone the repo to your local machine 
+```sh
+$ git clone https://github.com/muse-sisay/getGitRepo.git 
+```
+
+create an alias (in `~/.bashrc` if you are using BASH)
+```bash
+alias gitinit="bash /path/to/script/script.sh
+```
+
+## Setup
+
+### Generate SSH key 
+
+replace `muse-sisay` with your Github username. Only used for identification purpose. 
+
+```sh
+$ cd ~/.ssh
+$ ssh-keygen -f github-musesisay
+```
+
+[Github guide](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+
+### Edit ssh config
+
+Add this to your `~/.ssh/config`. Replace IdentityFile with the one you created. This will allow you to push commits with out providing a password.
+
+```text
+Host github.com
+    IdentityFile ~/.ssh/github-musesisay
+    IdentitiesOnly yes
+    Port 22
+```
+
+### Get Personal Access Token
+
+You can get a "personal access token in GitHub" by going to `Settings->Developer Settings-> Personal Access Tokens->Generate new token`. (select repo scope, or it won't work). # Edit this
+
+Save your Access Token!!
+
+## Usage
+
+```sh 
+$ gitinit -t token -u muse-sisay -r sampleRepo
+```
+
+This will create a `sampleRepo` repository on github.
+
+## TODO 
+- [ ] Securely store Access Token
+
+## Disclaimer 
+**Your Access Token with appear in your shell history!**

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ Host github.com
 
 You can get a "personal access token in GitHub" by going to `Settings->Developer Settings-> Personal Access Tokens->Generate new token`. (select repo scope, or it won't work). # Edit this
 
-Save your Access Token!!
+#### Save Access Token
+
+Create `ghAccessToken` in `~/.ssh` and place your access token inside `ghAccessToken`. Change permission to 600 so that only your user account has read and write access.  
+
+```sh
+$ cd ~/.ssh
+$ touch ghAccessToken
+$ chmod 600 ghAccessToken
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,10 @@ $ chmod 600 ghAccessToken
 ## Usage
 
 ```sh 
-$ gitinit -t token -u muse-sisay -r sampleRepo
+$ gitinit -t token -u muse-sisay -r sampleRepo -l mit
 ```
 
 This will create a `sampleRepo` repository on github.
 
 ## TODO 
 - [ ] Securely store Access Token
-
-## Disclaimer 
-**Your Access Token with appear in your shell history!**

--- a/script.sh
+++ b/script.sh
@@ -1,48 +1,123 @@
 #!/bin/sh
  
-LICENSES=("agpl-3.0" "apache-2.0" \
-        "bsd-2-clause" "bsd-3-clause"\
-        "bsl-1.0" "cc0-1.0" "epl-2.0" \
-        "gpl-2.0" "gpl-3.0" "lgpl-2.1"\
+LICENSES=("agpl-3.0" "apache-2.0" "bsd-2-clause" "bsd-3-clause"\
+        "bsl-1.0" "cc0-1.0" "epl-2.0" "gpl-2.0" "gpl-3.0" "lgpl-2.1"\
          "mit" "mpl-2.0" "unlicense" )
 
-function usage() # [] or () or <> , which one is optional
+USAGE="Syntax: gitinit  [-s] [-u GH_USERNAME] [-p PROJECT TITLE] [-l LICENSE] [-d PATH] \"Repository-name\""
+
+function usage()
 {
-    echo "Syntax: gitinit -t ACCESSTOKEN -u gh_username -r repo_name [ -p PROJECT TITLE ] [ -d path ]"
-    echo
-    echo "   A tool to intialize a git repo and push inital commit to github."
-    echo
-    echo "   options:"
-    echo "   s     Setup Private Repository."
-    echo "   h     Print this Help."
-    echo
-    echo "   arguments:"
-    echo "   -u USERNAME "
-    echo "   -r REPO NAME "
-    echo -e "   -p PROJECT TITLE  h1 displayed on README.md. Default is REPO NAME"
+    echo $USAGE
     exit 2
 }
 
-while getopts 'sl::u:r:p:d:h' args
-do 
+function help(){
+
+    echo "gitinit is tool for intialize a git repo and push an inital commit to github."
+    echo
+    echo $USAGE
+    echo "options:"
+    echo "h     Print this Help."
+    echo "-u    USERNAME "
+    echo "-p    PROJECT TITLE  h1 displayed on README.md. Defaults to repository-name"
+    echo "s     set as a private repository."
+    exit 2
+
+}
+
+function set_username(){
+    # Reads username from  git config 
+    user_name=$(awk '/name/ {print $3}' ~/.gitconfig)
+}
+function check_username(){
+
+    if [ -z "$user_name" ]; then 
+            echo "Missing username, can't find username in ~/.gitconfig"
+            usage
+    fi
+
+}
+
+function check_license(){ # ALT : check_valid_license
+    # valid license is passed
+    if [ ! -z $license ] && [[ ! " ${LICENSES[@]} " =~ " ${license} " ]]; then
+        echo "Invalid license \"$license\""
+        echo "License should be one of the following [${LICENSES[*]}]"
+        exit 2
+    fi
+}
+
+function directory_exists(){ # Check if directory exitsts
+
+    if [ ! -d "$loc" ]; then
+        echo "$0 : $loc : No such directory"
+        exit 3
+    fi
+}
+
+
+
+function setup_args(){
+
+    # USERNAME
+    [ -z "$user_name" ] && set_username
+    check_username
+
+    # API
+    # (read) Access/api token
+    api_token=$(cat ~/.ssh/ghAccessToken) # TODO : check if file exists
+    repo_name=${@: -1}
+
+    #  PROJECT TITLE
+    [ -z "$project_title" ] && project_title="$repo_name"
+
+    # REPO DIRECTORY
+    [ -z "$loc" ] && loc=$(pwd)
+
+}
+
+function create_local_repo_path(){
+    
+    cd "$loc"
+
+    if [ -d "$repo_name" ]; then
+        echo "$0: cannot create directory ‘${repo_name}’ in $loc : Project exists"
+        exit 3
+    fi 
+
+    mkdir "$repo_name"
+    cd "$repo_name"
+
+}
+
+function create_repo_files(){
+
+    echo "# $project_title" > README.md
+
+    if [ ! -z $license ]; then 
+        curl -s -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/licenses/$license | jq -r .body > LICENSE
+    fi 
+}
+while getopts 'sl::u:p:d:h' args ;do 
     case $args in 
         u) 
             user_name=$OPTARG
-        ;;
-        r) 
-            repo_name=$OPTARG
         ;;
         p) 
            project_title=$OPTARG
         ;;
         l)
             license=$OPTARG
+            check_license
         ;;
         d) 
             loc=$OPTARG
+            directory_exists
         ;;
         s) 
-            private_repo=",\"private\" : true"
+            private_repo=",\"private\" : true" #BUG : passing this without any arguments breaks the script
         ;;
         h |  *)
             usage
@@ -50,58 +125,13 @@ do
     esac
 done 
 
-# Check args 
-# repo name is setup
-[ -z "$repo_name" ] && usage
+setup_args
 
-# username is setup
-if [ -z "$user_name" ]; then 
-    # Read  git username from git config
-    user_name=$(awk '/name/ {print $3}' ~/.gitconfig)
+# LOCAL REPO
+create_local_repo_path
+create_repo_files
 
-    if [ -z "$user_name" ]; then 
-        echo "user_name is missing"
-        usage
-    fi
-fi 
-
-# valid license is passed
-if [ ! -z $license ] && [[ ! " ${LICENSES[@]} " =~ " ${license} " ]]; then
-    echo "Invalid license \"$license\""
-    echo "License should be one of the following [${LICENSES[*]}]"
-    exit 2
-fi
-
-# (read) Access/api token
- api_token=$(cat ~/.ssh/ghAccessToken)
-
-
-
-# Assign repo name to project title, if missing 
-if [ -z "$project_title" ]; then 
-    project_title="$repo_name"
-fi 
-
-
-if [ -z "$loc" ]; then
-    # Set current working directory if not set
-    loc=$(pwd)
-elif [ ! -d "$loc" ]; then
-    # Check if exists 
-    echo "$0 : $loc : No such directory"
-    exit 3
-fi
-
-cd "$loc"
-
-if [ -d "$repo_name" ]; then
-    echo "$0: cannot create directory ‘${repo_name}’ in $loc : Project exists"
-    exit 3
-fi 
-
-mkdir "$repo_name"
-cd "$repo_name"
-
+# REMOTE REPO
 if [ $(curl -s -o /dev/null -w "%{http_code}" \
                 -H "Authorization: token $api_token" "https://api.github.com/user/repos" \
                 -d "{\"name\": \"${repo_name}\" ${private_repo}}") -ne 201 ]; then
@@ -110,16 +140,8 @@ if [ $(curl -s -o /dev/null -w "%{http_code}" \
     exit 5
 fi
 
-
 git init
 git remote add origin git@github.com:"$user_name"/"$repo_name".git
-
-
-echo "# $project_title" > README.md
-if [ ! -z $license ]; then 
-    curl -s -H "Accept: application/vnd.github.v3+json" \
-        https://api.github.com/licenses/$license | jq -r .body > LICENSE
-fi 
 
 git add README.md LICENSE
 git commit -m "intial commit"

--- a/script.sh
+++ b/script.sh
@@ -47,8 +47,17 @@ done
 
 # Check args 
 [ -z "$api_token" ] && usage
-[ -z "$user_name" ] && usage
 [ -z "$repo_name" ] && usage
+
+if [ -z "$user_name" ]; then 
+    # Read  git username from git config
+    user_name=$(awk '/name/ {print $3}' ~/.gitconfig)
+
+    if [ -z "$user_name" ]; then 
+        echo "user_name is missing"
+        usage
+    fi
+fi 
 
 # Assign repo name to project title, if missing 
 if [ -z "$project_title" ]; then 
@@ -78,7 +87,8 @@ cd "$repo_name"
 if [ $(curl -s -o /dev/null -w "%{http_code}" \
                 -H "Authorization: token $api_token" "https://api.github.com/user/repos" \
                 -d "{\"name\": \"${repo_name}\" ${private_repo}}") -ne 201 ]; then
-
+    
+    echo "Unable to create remote repo."
     exit 5
 fi
 

--- a/script.sh
+++ b/script.sh
@@ -2,8 +2,20 @@
  
 function usage() # [] or () or <> , which one is optional
 {
-  echo "Usage: $0 -t ACCESSTOKEN -u gh_username -r repo_name [ -p PROJECT TITLE ] [ -d path ]" >&2
-  exit 2
+    echo "Syntax: gitinit -t ACCESSTOKEN -u gh_username -r repo_name [ -p PROJECT TITLE ] [ -d path ]"
+    echo
+    echo "   A tool to intialize a git repo and push inital commit to github."
+    echo
+    echo "   options:"
+    echo "   s     Setup Private Repository."
+    echo "   h     Print this Help."
+    echo
+    echo "   arguments:"
+    echo "   -t ACCESSTOKEN"
+    echo "   -u USERNAME "
+    echo "   -r REPO NAME "
+    echo -e "   -p PROJECT TITLE  h1 displayed on README.md. Default is REPO NAME"
+    exit 2
 }
 
 while getopts 'st:u:r:p:d:h' args

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
  
-LICENSES=("agpl-3.0" "apache-2.0" "bsd-2-clause" "bsd-3-clause"\
-        "bsl-1.0" "cc0-1.0" "epl-2.0" "gpl-2.0" "gpl-3.0" "lgpl-2.1"\
+LICENSES=("agpl-3.0" "apache-2.0" "bsd-2-clause" "bsd-3-clause" \
+        "bsl-1.0" "cc0-1.0" "epl-2.0" "gpl-2.0" "gpl-3.0" "lgpl-2.1" \
          "mit" "mpl-2.0" "unlicense" )
 
 USAGE="Syntax: gitinit  [-s] [-u GH_USERNAME] [-p PROJECT TITLE] [-l LICENSE] [-d PATH] \"Repository-name\""
@@ -14,29 +14,48 @@ function usage()
 
 function help(){
 
-    echo "gitinit is tool for intialize a git repo and push an inital commit to github."
+    echo
+    echo "gitinit is tool for intialize a git repo and push an inital commit to Github."
     echo
     echo $USAGE
-    echo "options:"
-    echo "h     Print this Help."
-    echo "-u    USERNAME "
-    echo "-p    PROJECT TITLE  h1 displayed on README.md. Defaults to repository-name"
-    echo "s     set as a private repository."
+    echo
+    echo " options:"
+    echo "  - h    Print this Help."
+    echo "  - u    git USERNAME "
+    echo "  - p    PROJECT TITLE  heading displayed on README.md. Defaults to repository-name"
+    echo "  - s    set as a private repository."
+    echo
     exit 2
 
 }
 
-function set_username(){
+function read_global_git_config(){
     # Reads username from  git config 
-    user_name=$(awk '/name/ {print $3}' ~/.gitconfig)
+    global_git_user=$(awk '/name/ {print $3}' ~/.gitconfig 2> /dev/null)
+    
+    if [ "$?"  -eq 2 ] && [ -z "$git_user" ]; then 
+        echo "Missing global git config. Add using "
+        echo "    git config --global user.name"
+        echo "    git config --global user.email"
+        exit 
+    fi
 }
-function check_username(){
 
-    if [ -z "$user_name" ]; then 
-            echo "Missing username, can't find username in ~/.gitconfig"
-            usage
+function set_username(){
+   
+    read_global_git_config
+
+    if [ -z "$git_user" ]; then
+        git_user=$global_git_user
     fi
 
+    # Only create a local git config  
+    # if git_user is diffrent  global_git_user
+    if [ $git_user != $global_git_user ]; then
+        # Prompt for git email
+        read -p "Git email: " git_email
+        set_local_repo="true"
+    fi
 }
 
 function check_license(){ # ALT : check_valid_license
@@ -56,18 +75,15 @@ function directory_exists(){ # Check if directory exitsts
     fi
 }
 
-
-
 function setup_args(){
 
     # USERNAME
-    [ -z "$user_name" ] && set_username
-    check_username
+    set_username
 
     # API
     # (read) Access/api token
     api_token=$(cat ~/.ssh/ghAccessToken) # TODO : check if file exists
-    repo_name=${@: -1}
+    repo_name=$1
 
     #  PROJECT TITLE
     [ -z "$project_title" ] && project_title="$repo_name"
@@ -81,7 +97,7 @@ function create_local_repo_path(){
     
     cd "$loc"
 
-    if [ -d "$repo_name" ]; then
+    if [ -e "$repo_name" ]; then
         echo "$0: cannot create directory ‘${repo_name}’ in $loc : Project exists"
         exit 3
     fi 
@@ -91,7 +107,7 @@ function create_local_repo_path(){
 
 }
 
-function create_repo_files(){
+function create_project_files(){
 
     echo "# $project_title" > README.md
 
@@ -100,10 +116,29 @@ function create_repo_files(){
             https://api.github.com/licenses/$license | jq -r .body > LICENSE
     fi 
 }
-while getopts 'sl::u:p:d:h' args ;do 
+
+function intialize_repo(){
+    
+    git init
+
+    if [ ! -z $set_local_repo ]; then 
+        git config user.name $git_user
+        git config user.email $git_email
+    fi
+
+    git remote add origin git@"github-${git_user}":"$git_user"/"$repo_name".git
+
+    git add README.md LICENSE
+    git commit -m "intial commit"
+}
+
+# /////////////////////////////////////////////
+# ////////////////////////////////////////////
+
+while getopts 'sl:u:p:d:h' args "${@:1:$#-1}" ;do 
     case $args in 
         u) 
-            user_name=$OPTARG
+            git_user=$OPTARG
         ;;
         p) 
            project_title=$OPTARG
@@ -120,16 +155,17 @@ while getopts 'sl::u:p:d:h' args ;do
             private_repo=",\"private\" : true" #BUG : passing this without any arguments breaks the script
         ;;
         h |  *)
-            usage
+            help
         ;;
     esac
 done 
 
-setup_args
+setup_args ${@: -1}
 
 # LOCAL REPO
 create_local_repo_path
-create_repo_files
+create_project_files
+intialize_repo 
 
 # REMOTE REPO
 if [ $(curl -s -o /dev/null -w "%{http_code}" \
@@ -139,11 +175,5 @@ if [ $(curl -s -o /dev/null -w "%{http_code}" \
     echo "Unable to create remote repo."
     exit 5
 fi
-
-git init
-git remote add origin git@github.com:"$user_name"/"$repo_name".git
-
-git add README.md LICENSE
-git commit -m "intial commit"
 
 git push -u origin master

--- a/script.sh
+++ b/script.sh
@@ -6,7 +6,7 @@ function usage() # [] or () or <> , which one is optional
   exit 2
 }
 
-while getopts 't:u:r:p:d:h' args
+while getopts 'st:u:r:p:d:h' args
 do 
     case $args in 
         t) 
@@ -23,6 +23,9 @@ do
         ;;
         d) 
             loc=$OPTARG
+        ;;
+        s) 
+            private_repo=",\"private\" : true"
         ;;
         h |  *)
             usage
@@ -60,10 +63,9 @@ fi
 mkdir "$repo_name"
 cd "$repo_name"
 
-
 if [ $(curl -s -o /dev/null -w "%{http_code}" \
                 -H "Authorization: token $api_token" "https://api.github.com/user/repos" \
-                -d "{\"name\": \"${repo_name}\"}") -ne 201 ]; then
+                -d "{\"name\": \"${repo_name}\" ${private_repo}}") -ne 201 ]; then
 
     exit 5
 fi

--- a/script.sh
+++ b/script.sh
@@ -1,18 +1,80 @@
 #!/bin/sh
+ 
+function usage() # [] or () or <> , which one is optional
+{
+  echo "Usage: $0 -t ACCESSTOKEN -u gh_username -r repo_name [ -p PROJECT TITLE ] [ -d path ]" >&2
+  exit 2
+}
 
-echo "enter repo name : "
-read repo_name
+while getopts 't:u:r:p:d:h' args
+do 
+    case $args in 
+        t) 
+            api_token=$OPTARG
+        ;;
+        u) 
+            user_name=$OPTARG
+        ;;
+        r) 
+            repo_name=$OPTARG
+        ;;
+        p) 
+           project_title=$OPTARG
+        ;;
+        d) 
+            loc=$OPTARG
+        ;;
+        h |  *)
+            usage
+        ;;
+    esac
+done 
+
+# Check args 
+[ -z "$api_token" ] && usage
+[ -z "$user_name" ] && usage
+[ -z "$repo_name" ] && usage
+
+# Assign repo name to project title, if missing 
+if [ -z "$project_title" ]; then 
+    project_title="$repo_name"
+fi 
 
 
-test -z $repo_name && echo "Repo name required." 1>&2 && exit 1
-#AbrahamTerfie is my git username replace yours with your own 
-curl -u 'AbrahamTerfie' https://api.github.com/user/repos -d "{\"name\":\"$repo_name\"}"
+if [ -z "$loc" ]; then
+    # Set current working directory if not set
+    loc=$(pwd)
+elif [ ! -d "$loc" ]; then
+    # Check if exists 
+    echo "$0 : $loc : No such directory"
+    exit 3
+fi
 
-echo "repo created sucesfully "
-touch README.md
+cd "$loc"
+
+if [ -d "$repo_name" ]; then
+    echo "$0: cannot create directory ‘${repo_name}’ in $loc : Project exists"
+    exit 3
+fi 
+
+mkdir "$repo_name"
+cd "$repo_name"
+
+
+if [ $(curl -s -o /dev/null -w "%{http_code}" \
+                -H "Authorization: token $api_token" "https://api.github.com/user/repos" \
+                -d "{\"name\": \"${repo_name}\"}") -ne 201 ]; then
+
+    exit 5
+fi
+
+
 git init
+git remote add origin git@github.com:"$user_name"/"$repo_name".git
+
+echo "# $project_title" > README.md
+
 git add README.md
-git add .
-git commit -m "first commit"
-git remote add origin https://github.com/AbrahamTerfie/$repo_name.git
+git commit -m "intial commit"
+
 git push -u origin master

--- a/script.sh
+++ b/script.sh
@@ -11,7 +11,6 @@ function usage() # [] or () or <> , which one is optional
     echo "   h     Print this Help."
     echo
     echo "   arguments:"
-    echo "   -t ACCESSTOKEN"
     echo "   -u USERNAME "
     echo "   -r REPO NAME "
     echo -e "   -p PROJECT TITLE  h1 displayed on README.md. Default is REPO NAME"
@@ -21,9 +20,6 @@ function usage() # [] or () or <> , which one is optional
 while getopts 'st:u:r:p:d:h' args
 do 
     case $args in 
-        t) 
-            api_token=$OPTARG
-        ;;
         u) 
             user_name=$OPTARG
         ;;
@@ -45,8 +41,10 @@ do
     esac
 done 
 
+# (read) Access/api token
+ api_token=$(cat ~/.ssh/ghAccessToken)
+
 # Check args 
-[ -z "$api_token" ] && usage
 [ -z "$repo_name" ] && usage
 
 if [ -z "$user_name" ]; then 


### PR DESCRIPTION
This Pull Request contains the following  changes :
- parse cli arguments, using `getopts`
- introduce cli arguments for specifying `repository location`, `repository name` and `project name`.
-  use access  token's and ssh key's instead of password for authentication 
- updated README.md